### PR TITLE
Add variable board size functionality

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,30 +1,29 @@
-
 class Board
 
   attr_reader :cells
 
-    def initialize
-       #@rows = ["A","B","C","D"]
-       @columns = [1, 2, 3, 4]
-       @cells = {
-        "A1" => Cell.new("A1"),
-        "A2" => Cell.new("A2"),
-        "A3" => Cell.new("A3"),
-        "A4" => Cell.new("A4"),
-        "B1" => Cell.new("B1"),
-        "B2" => Cell.new("B2"),
-        "B3" => Cell.new("B3"),
-        "B4" => Cell.new("B4"),
-        "C1" => Cell.new("C1"),
-        "C2" => Cell.new("C2"),
-        "C3" => Cell.new("C3"),
-        "C4" => Cell.new("C4"),
-        "D1" => Cell.new("D1"),
-        "D2" => Cell.new("D2"),
-        "D3" => Cell.new("D3"),
-        "D4" => Cell.new("D4")
+    def initialize(row_count = 4, column_count = 4)
+       @cells = {}
+       number_to_letter = (1..26).zip("A".."Z").to_h
 
-      }
+      # limit max size of board
+      row_count = 26 if row_count > 26
+      row_count = 3 if row_count < 3
+      column_count = 9 if column_count > 9
+      column_count = 3 if column_count < 3
+
+      # create rows and columns
+      @rows = (number_to_letter[1]..number_to_letter[row_count]).to_a
+      # @rows = ["A","B","C","D"]
+      @columns = (1..column_count).to_a
+      # @columns = [1,2,3,4]
+
+      # create cells
+      @rows.each do |row|
+        @columns.each do |column|
+          @cells["#{row}#{column}"] = Cell.new("#{row}#{column}")
+        end
+      end
     end
 
     def valid_coordinate?(coordinate)
@@ -45,12 +44,12 @@ class Board
         # is ship on consecutive rows?
         consecutive_rows = coordinate_pairs.all? do |pair|
           pair[0][0] == pair[1][0] &&
-          pair[0][1].to_i + 1 == pair[1][1].to_i
+          pair[0][-1].to_i + 1 == pair[-1][-1].to_i
         end
         # is ship on consecutive columns?
         consecutive_columns = coordinate_pairs.all? do |pair|
-          pair[0][0].ord + 1 == pair[1][0].ord &&
-          pair[0][1] == pair[1][1]
+          pair[0][0].ord + 1 == pair[-1][0].ord &&
+          pair[0][-1] == pair[-1][-1]
         end
         # do ships overlap?
         overlap = @cells.count do |k,v|
@@ -66,7 +65,7 @@ class Board
 
     def place(ship, ship_coordinates)
       if valid_placement?(ship, ship_coordinates)
-        ship_coordinates.each do|coordinate|
+        ship_coordinates.each do |coordinate|
           @cells[coordinate].place_ship(ship)
         end
       else
@@ -75,20 +74,38 @@ class Board
     end
 
     def render(status = false)
-
-      columns = "  1 2 3 4"
-      a_row = "A"
-      b_row = "B"
-      c_row = "C"
-      d_row = "D"
+      render_columns = " "
       @columns.each do |column|
-        a_row.concat(" #{cells["A#{column}"].render(status)}")
-        b_row.concat(" #{cells["B#{column}"].render(status)}")
-        c_row.concat(" #{cells["C#{column}"].render(status)}")
-        d_row.concat(" #{cells["D#{column}"].render(status)}")
+        render_columns.concat(" #{column}")
       end
 
-      output = "#{columns} \n#{a_row} \n#{b_row} \n#{c_row} \n#{d_row} \n"
+      render_rows = ""
+      group_by_rows = @cells.group_by do |k,v|
+        k[0]
+      end
+      group_by_rows.each do |k,v|
+        render_rows.concat("#{k}")
+        v.each do |cell|
+          render_rows.concat(" #{cell[1].render(status)}")
+        end
+        render_rows.concat(" \n")
+        # puts render_rows
+      end
+      output = "#{render_columns} \n#{render_rows}"
+
+      # columns = "  1 2 3 4"
+      # a_row = "A"
+      # b_row = "B"
+      # c_row = "C"
+      # d_row = "D"
+      # @columns.each do |column|
+      #   a_row.concat(" #{cells["A#{column}"].render(status)}")
+      #   b_row.concat(" #{cells["B#{column}"].render(status)}")
+      #   c_row.concat(" #{cells["C#{column}"].render(status)}")
+      #   d_row.concat(" #{cells["D#{column}"].render(status)}")
+      # end
+      #
+      # output = "#{columns} \n#{a_row} \n#{b_row} \n#{c_row} \n#{d_row} \n"
     end
 
 end

--- a/lib/round.rb
+++ b/lib/round.rb
@@ -1,8 +1,8 @@
 class Round
 
   def initialize
-    @player_board = Board.new
-    @computer_board = Board.new
+    @player_board = nil
+    @computer_board = nil
     @player_ship_count = 2
     @computer_ship_count = 2
   end
@@ -10,17 +10,37 @@ class Round
   def start
     puts "Welcome to BATTLESHIP\nEnter p to play. Enter q to quit."
     menu_input = gets.chomp.to_s.downcase
-    if menu_input == "q"
+    if menu_input[0] == "q"
       puts "You quit the game."
-    elsif menu_input != "p"
+    elsif menu_input[0] != "p"
       puts "Invalid."
       start
-    elsif menu_input == "p"
+    elsif menu_input[0] == "p"
       game_steps
     end
   end
 
   def welcome
+    puts "Would you like to use the standard board size (4x4)?"
+    board_input = gets.chomp.to_s.downcase
+
+    if board_input[0] == "n"
+      puts "How many rows would you like?"
+      height_input = gets.chomp.to_i
+      puts "How many columns would you like?"
+      width_input = gets.chomp.to_i
+
+      @player_board = Board.new(height_input, width_input)
+      @computer_board = Board.new(height_input, width_input)
+
+    elsif board_input[0] == "y"
+      @player_board = Board.new
+      @computer_board = Board.new
+    else
+      puts "Invalid. Please respond with yes or no."
+      welcome
+    end
+
     puts "I have laid out my ships on the grid."
     puts "You now need to lay out your two ships."
     puts "The Cruiser is three units long and the Submarine is two units long."
@@ -135,16 +155,13 @@ class Round
   def results
     if @computer_ship_count == 0
       puts "Your opponent has no remaining ships. You win!"
-      puts "\n"
     elsif @player_ship_count == 0
       puts "You have no remaining ships. Try again sailor."
-      puts "\n"
     end
+    puts "\n"
   end
 
   def reset
-    @player_board = Board.new
-    @computer_board = Board.new
     @player_ship_count = 2
     @computer_ship_count = 2
   end


### PR DESCRIPTION
Updated Board and Round classes to accommodate variable board size feature, up to 9 columns and 26 rows. All tests still pass.
New code in Board initialize generates variable number of cells.
New code in Board render adapts to print variable size board. Previous Board render method remains, commented out.
Variable column size is currently limited by valid_placement? method, which bugs out with numbers in a coordinate above 9, due to the way it reads coordinates.
Variable row size is limited by the number of letters in the alphabet.
Round class had additions to welcome method to ask for board size input.